### PR TITLE
fix mysql broken pipe

### DIFF
--- a/index/index_update_all_task.go
+++ b/index/index_update_all_task.go
@@ -48,7 +48,7 @@ func UpdateIndexOne(endpoint string, metric string, tags map[string]string, dsty
 	}
 	gitem := icitem.Item
 
-	dbConn, err := g.GetDbConn("UpdateIndexAllTask")
+	dbConn, err := g.GetDbConn("UpdateIndexIncrTask")
 	if err != nil {
 		log.Println("[ERROR] make dbConn fail", err)
 		return err
@@ -97,7 +97,7 @@ func updateIndexAll(updateStepInSec int64) int {
 		return ret
 	}
 
-	dbConn, err := g.GetDbConn("UpdateIndexAllTask")
+	dbConn, err := g.GetDbConn("UpdateIndexIncrTask")
 	if err != nil {
 		log.Println("[ERROR] make dbConn fail", err)
 		return ret


### PR DESCRIPTION
去掉长时间不使用的mysql连接，防止mysq的server端wait_timeout后 造成连接不可用、进而产生broken pipe的错误日志
