### PR TITLE
sort node before added consistent hashing

### DIFF
--- a/rrdtool/migrate.go
+++ b/rrdtool/migrate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/toolkits/consistent"
 
 	cmodel "github.com/open-falcon/common/model"
+	cutils "github.com/open-falcon/common/utils"
 	"github.com/open-falcon/graph/g"
 	"github.com/open-falcon/graph/store"
 )
@@ -94,7 +95,9 @@ func migrate_start(cfg *g.GlobalConfig) {
 	if cfg.Migrate.Enabled {
 		Consistent.NumberOfReplicas = cfg.Migrate.Replicas
 
-		for node, addr := range cfg.Migrate.Cluster {
+		nodes := cutils.KeysOfMap(cfg.Migrate.Cluster)
+		for _, node := range nodes {
+			addr := cfg.Migrate.Cluster[node]
 			Consistent.Add(node)
 			Net_task_ch[node] = make(chan *Net_task_t, 16)
 			clients[node] = make([]*rpc.Client, cfg.Migrate.Concurrency)


### PR DESCRIPTION
现在一致性hash的server的配置都是走的map的方式。但是这样有一个问题：如果生成hash ring的时候有冲突，使用map的方式就会有问题，因为map的迭代顺序是不确定的。比如如果A和Bhash有冲突，有可能在transfer的时候先迭代A再迭代B，则最终以B为准，但是在query的时候先迭代B再迭代A，查询的时候以A为准。这样就会有实际落在B的机器数据，但是查询的时候去A查的问题

没有冲突的时候是没关系的，但是有冲突的时候就不是了，这个时候看具体的处理策略了。可以覆盖旧值，可以rehash。这个时候冲突的两个点就有先后顺序的问题了
### 相关的几个PR需要同时合并
- [transfer](https://github.com/open-falcon/transfer/pull/11)
- [common](https://github.com/open-falcon/common/pull/4)
