### PR TITLE
增加step参数，可用于控制查询的精度

### DIFF
--- a/g/git.go
+++ b/g/git.go
@@ -1,5 +1,4 @@
 package g
-
 const (
-	COMMIT = "gitversion"
+    COMMIT = "15b66f2"
 )

--- a/rrdtool/sync_disk.go
+++ b/rrdtool/sync_disk.go
@@ -96,7 +96,7 @@ func ioWorker() {
 				}
 			} else if task.method == IO_TASK_M_FETCH {
 				if args, ok := task.args.(*fetch_t); ok {
-					args.data, err = fetch(args.filename, args.cf, args.start, args.end, args.step)
+					args.data, args.step, err = fetch(args.filename, args.cf, args.start, args.end, args.step)
 					task.done <- err
 				}
 			}


### PR DESCRIPTION
1、增加step参数，用于query控制查询的精度
2、修复start % step == 0时，第1点数据取值为0的问题
3、查询数据时，将内存中的数据，也进行归档，将归档的数据补充在最后，返回给query