### PR TITLE
fix graph migration 'no such file or directory' rpc_call error bug

### DIFF
--- a/rrdtool/migrate.go
+++ b/rrdtool/migrate.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net"
 	"net/rpc"
-	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -145,7 +145,7 @@ func net_task_worker(idx int, ch chan *Net_task_t, client **rpc.Client, addr str
 					}
 				} else {
 					if err = fetch_rrd(client, task.Key, addr); err != nil {
-						if os.IsNotExist(err) {
+						if strings.Contains(err.Error(), "no such file or directory") {
 							pfc.Meter("migrate.scprrd.null", 1)
 							//文件不存在时，直接将缓存数据刷入本地
 							atomic.AddUint64(&stat_cnt[FETCH_S_ISNOTEXIST], 1)


### PR DESCRIPTION
**描述：**
进行graph迁移时，会出现migrate.go:301: open /opt/open-falcon/graph/data/6070/35/356aa82f9c00c1edd11102696313c636_GAUGE_60.rrd: no such file or directory这样的报错，并且该报错会持续发生，每次落盘周期30分钟一次，经查证，为代码段：
`if os.IsNotExist(err) {`
并未成功判断该err为os.IsNotExist（“文件不存在”）这个错误类型所造成，查看go源码，发现os.IsNotExist只针对PathError有效，可判断其是否为os.IsNotExist，但对rpc_call返回的普通error无法判断，造成if语句无法按预期判断，迁移时，一旦有新的指标项传入新的graph，则会报fetch_s_error，并无法落盘，只能写入内存。
**可能的隐患：**
如果迁移长时间持续进行，中途未进行重启graph的操作，新的指标监控项会造成内存数据持续增加，直至OOM，并且会造成log日志持续写入，日志增长过快。
**解决方式：**
修改`if os.IsNotExist(err) {`为`if strings.Contains(err.Error(), "no such file or directory")`，直接对rpc_call返回的error进行内容判断，经测试验证通过

Signed-off-by: Xin He <hexin@jiedaibao.com>